### PR TITLE
Clear trade selections on team change and improve comparison modal

### DIFF
--- a/DH-HQ_M4.58/rosters/rosters.html
+++ b/DH-HQ_M4.58/rosters/rosters.html
@@ -171,8 +171,8 @@
 </div>
 </div>
 
+<div id="comparison-overlay" class="hidden"></div>
 <div id="player-comparison-modal" class="hidden">
-  <div class="modal-overlay"></div>
   <div class="modal-content glass-panel">
     <button class="modal-close-btn">&times;</button>
     <div id="comparison-modal-header">

--- a/DH-HQ_M4.58/rosters/rosters.html
+++ b/DH-HQ_M4.58/rosters/rosters.html
@@ -188,6 +188,7 @@
       <!-- Footer content can be added here if needed -->
     </div>
   </div>
+</div>
 <script defer="True" src="../scripts/app.js?v=20250826235225"></script></body>
 </html>
 

--- a/DH-HQ_M4.58/scripts/app.js
+++ b/DH-HQ_M4.58/scripts/app.js
@@ -35,6 +35,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const modalPlayerName = document.getElementById('modal-player-name');
         const modalBody = document.getElementById('modal-body');
         const playerComparisonModal = document.getElementById('player-comparison-modal');
+        const comparisonOverlay = document.getElementById('comparison-overlay');
 
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
@@ -208,9 +209,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             if (playerComparisonModal) {
                 const closeBtn = playerComparisonModal.querySelector('.modal-close-btn');
-                const overlay = playerComparisonModal.querySelector('.modal-overlay');
                 if (closeBtn) closeBtn.addEventListener('click', () => closeComparisonModal());
-                if (overlay) overlay.addEventListener('click', () => closeComparisonModal());
                 document.addEventListener('keydown', (e) => {
                     if (e.key === 'Escape' && !playerComparisonModal.classList.contains('hidden')) {
                         closeComparisonModal();
@@ -386,15 +385,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const isSelected = state.teamsToCompare.has(teamName);
 
                 if (isSelected) {
-                    // If a team is deselected, hide the trade preview
+                    // If a team is deselected, hide the trade preview and clear selections
                     state.teamsToCompare.delete(teamName);
                     checkbox.classList.remove('selected');
 
                     state.isCompareMode = false;
+                    clearTrade();
                     rosterView.classList.remove('is-trade-mode');
                     rosterGrid.classList.remove('is-preview-mode');
                     renderAllTeamData(state.currentTeams);
-                    renderTradeBlock();
                     updateHeaderPreviewState();
 
                 } else {
@@ -2146,6 +2145,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
 
                 playerComparisonModal.classList.remove('hidden');
+                comparisonOverlay?.classList.remove('hidden');
             }
         }
 
@@ -2159,7 +2159,17 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
                 playerComparisonModal.classList.add('hidden');
             }
+            comparisonOverlay?.classList.add('hidden');
         }
+
+        comparisonOverlay?.addEventListener('click', closeComparisonModal);
+
+        document.addEventListener('click', (e) => {
+            if (!playerComparisonModal || playerComparisonModal.classList.contains('hidden')) return;
+            if (playerComparisonModal.contains(e.target)) return;
+            if (tradeSimulator && tradeSimulator.contains(e.target)) return;
+            closeComparisonModal();
+        });
 
         function setLoading(isLoading, message = 'Loading...') {
             welcomeScreen?.classList.add('hidden');

--- a/DH-HQ_M4.58/scripts/app.js
+++ b/DH-HQ_M4.58/scripts/app.js
@@ -2157,6 +2157,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     modalContent.style.height = '';
                     modalContent.style.bottom = '';
                 }
+                const comparisonModalBody = document.getElementById('comparison-modal-body');
+                if (comparisonModalBody) comparisonModalBody.innerHTML = '';
                 playerComparisonModal.classList.add('hidden');
             }
             comparisonOverlay?.classList.add('hidden');

--- a/DH-HQ_M4.58/styles/styles.css
+++ b/DH-HQ_M4.58/styles/styles.css
@@ -3443,6 +3443,19 @@ img.team-logo.glow[alt="WAS"] {
 }
 
 
+/* === Overlay for Player Comparison Modal === */
+#comparison-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 5; /* below header (10) and trade preview (20) */
+}
+#comparison-overlay.hidden {
+  display: none;
+}
+
 /* === Player Comparison Modal Layout (fits between header and trade preview) === */
 #player-comparison-modal {
   position: fixed;
@@ -3451,9 +3464,6 @@ img.team-logo.glow[alt="WAS"] {
   display: block;         /* don't center via flex */
   pointer-events: none;   /* allow clicks only on content panel */
   background: transparent;/* no backdrop for this modal */
-}
-#player-comparison-modal .modal-overlay {
-  display: none;          /* hide dim overlay for this modal */
 }
 #player-comparison-modal .modal-content {
   position: fixed;        /* we’ll set top/height via JS in openComparisonModal() */

--- a/DH-HQ_M4.58/styles/styles.css
+++ b/DH-HQ_M4.58/styles/styles.css
@@ -3447,7 +3447,7 @@ img.team-logo.glow[alt="WAS"] {
 #comparison-overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(255, 255, 255, 0.01);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   z-index: 5; /* below header (10) and trade preview (20) */


### PR DESCRIPTION
## Summary
- Clear trade selections and close comparison modal when teams are deselected
- Add background overlay and automatic dismissal for player comparison modal
- Style and wire overlay behind header and trade preview for better accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c777002044832e9d9ff58cd5485888