### PR TITLE
Fix player comparison modal interactions and trade cleanup

### DIFF
--- a/DH-HQ_M4.58/rosters/rosters.html
+++ b/DH-HQ_M4.58/rosters/rosters.html
@@ -168,11 +168,11 @@
     <span>Key</span>
   </div>
 </div>
-</div>
+ </div>
 </div>
 
+<div id="player-comparison-overlay" class="modal-overlay hidden"></div>
 <div id="player-comparison-modal" class="hidden">
-  <div class="modal-overlay"></div>
   <div class="modal-content glass-panel">
     <button class="modal-close-btn">&times;</button>
     <div id="comparison-modal-header">
@@ -188,6 +188,7 @@
       <!-- Footer content can be added here if needed -->
     </div>
   </div>
+</div>
 <script defer="True" src="../scripts/app.js?v=20250826235225"></script></body>
 </html>
 

--- a/DH-HQ_M4.58/scripts/app.js
+++ b/DH-HQ_M4.58/scripts/app.js
@@ -28,13 +28,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const pageType = document.body.dataset.page || 'welcome';
 
         const gameLogsModal = document.getElementById('game-logs-modal');
-        const modalCloseBtn = document.querySelector('.modal-close-btn');
-        const modalInfoBtn = document.querySelector('.modal-info-btn');
+        const modalCloseBtn = gameLogsModal ? gameLogsModal.querySelector('.modal-close-btn') : null;
+        const modalInfoBtn = gameLogsModal ? gameLogsModal.querySelector('.modal-info-btn') : null;
         const statsKeyContainer = document.getElementById('stats-key-container');
-        const modalOverlay = document.querySelector('.modal-overlay');
+        const modalOverlay = gameLogsModal ? gameLogsModal.querySelector('.modal-overlay') : null;
         const modalPlayerName = document.getElementById('modal-player-name');
         const modalBody = document.getElementById('modal-body');
         const playerComparisonModal = document.getElementById('player-comparison-modal');
+        const playerComparisonOverlay = document.getElementById('player-comparison-overlay');
 
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
@@ -208,15 +209,25 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             if (playerComparisonModal) {
                 const closeBtn = playerComparisonModal.querySelector('.modal-close-btn');
-                const overlay = playerComparisonModal.querySelector('.modal-overlay');
                 if (closeBtn) closeBtn.addEventListener('click', () => closeComparisonModal());
-                if (overlay) overlay.addEventListener('click', () => closeComparisonModal());
                 document.addEventListener('keydown', (e) => {
                     if (e.key === 'Escape' && !playerComparisonModal.classList.contains('hidden')) {
                         closeComparisonModal();
                     }
                 });
             }
+
+            if (playerComparisonOverlay) {
+                playerComparisonOverlay.addEventListener('click', () => clearTrade());
+            }
+
+            document.addEventListener('click', (e) => {
+                if (playerComparisonModal?.classList.contains('hidden')) return;
+                if (playerComparisonModal.contains(e.target)) return;
+                if (tradeSimulator.contains(e.target)) return;
+                if (gameLogsModal?.contains(e.target)) return;
+                clearTrade();
+            });
         }
         
         // --- Initialization ---
@@ -389,12 +400,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     // If a team is deselected, hide the trade preview
                     state.teamsToCompare.delete(teamName);
                     checkbox.classList.remove('selected');
-
+                    clearTrade();
                     state.isCompareMode = false;
                     rosterView.classList.remove('is-trade-mode');
                     rosterGrid.classList.remove('is-preview-mode');
                     renderAllTeamData(state.currentTeams);
-                    renderTradeBlock();
                     updateHeaderPreviewState();
 
                 } else {
@@ -2146,6 +2156,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
 
                 playerComparisonModal.classList.remove('hidden');
+                playerComparisonOverlay?.classList.remove('hidden');
             }
         }
 
@@ -2159,6 +2170,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
                 playerComparisonModal.classList.add('hidden');
             }
+            playerComparisonOverlay?.classList.add('hidden');
         }
 
         function setLoading(isLoading, message = 'Loading...') {

--- a/DH-HQ_M4.58/styles/styles.css
+++ b/DH-HQ_M4.58/styles/styles.css
@@ -3444,6 +3444,11 @@ img.team-logo.glow[alt="WAS"] {
 
 
 /* === Player Comparison Modal Layout (fits between header and trade preview) === */
+#player-comparison-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 5;             /* below header (10) and trade preview (20) */
+}
 #player-comparison-modal {
   position: fixed;
   inset: 0;
@@ -3451,9 +3456,6 @@ img.team-logo.glow[alt="WAS"] {
   display: block;         /* don't center via flex */
   pointer-events: none;   /* allow clicks only on content panel */
   background: transparent;/* no backdrop for this modal */
-}
-#player-comparison-modal .modal-overlay {
-  display: none;          /* hide dim overlay for this modal */
 }
 #player-comparison-modal .modal-content {
   position: fixed;        /* we’ll set top/height via JS in openComparisonModal() */


### PR DESCRIPTION
## Summary
- Reset trade selections when teams are deselected
- Close and clear player compare modal when clicking outside (but allow trade preview interaction)
- Add background overlay behind header and trade preview for player compare modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c777002044832e9d9ff58cd5485888