### PR TITLE
Improve player comparison modal handling

### DIFF
--- a/DH_P2-5/scripts/app.js
+++ b/DH_P2-5/scripts/app.js
@@ -178,6 +178,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             tradeSimulator.addEventListener('click', (e) => {
                 if (e.target.closest('#comparePlayersButton')) {
+                    if (playerComparisonModal && !playerComparisonModal.classList.contains('hidden')) {
+                        closeComparisonModal();
+                        return;
+                    }
                     const selectedPlayers = Object.values(state.tradeBlock).flat().filter(asset => asset.pos !== 'DP');
                     if (selectedPlayers.length !== 2) {
                         showTemporaryTooltip(e.target.closest('#comparePlayersButton'), 'Please select exactly 2 players to compare.');
@@ -1717,8 +1721,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
   const isEligible = state.isCompareMode && state.teamsToCompare.size >= 2;
 
   if (!isEligible) {
+    state.tradeBlock = {};
+    document.querySelectorAll('.player-selected').forEach(el => el.classList.remove('player-selected'));
     tradeSimulator.style.display = 'none';
     mainContent.style.paddingBottom = '1rem';
+    closeComparisonModal();
     return;
   }
 
@@ -1838,6 +1845,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
             document.getElementById('collapseTradeButton').addEventListener('click', () => {
+                closeComparisonModal();
                 tradeSimulator.classList.add('collapsed');
                 state.isTradeCollapsed = true;
                 mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 20}px`;
@@ -2174,6 +2182,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (comparisonBackgroundOverlay) {
                     comparisonBackgroundOverlay.classList.remove('hidden');
                 }
+                if (rosterGrid) {
+                    rosterGrid.classList.add('hidden');
+                }
             }
         }
 
@@ -2193,6 +2204,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (comparisonModalBody) {
                     comparisonModalBody.innerHTML = '';
                 }
+            }
+            if (rosterGrid) {
+                rosterGrid.classList.remove('hidden');
             }
         }
 

--- a/DH_P2-5/styles/styles.css
+++ b/DH_P2-5/styles/styles.css
@@ -694,6 +694,7 @@
             justify-content: flex-start;
             align-items: center;
             gap: 0.4rem;
+            pointer-events: none;
         }
     .player-name { 
             font-weight: 400; 
@@ -703,6 +704,7 @@
             white-space: nowrap !important;
             text-decoration: underline;
             text-decoration-color: #9096D090;
+            pointer-events: auto;
         }
         .player-tag {
             display: inline-flex;
@@ -713,6 +715,7 @@
             padding: 1px 3px;
             border-radius: 4px;
             color: var(--color-bg);
+            pointer-events: auto;
             line-height: 1;
         }
 
@@ -3343,7 +3346,7 @@ img.team-logo.glow[alt="WAS"] {
 #player-comparison-modal {
   position: fixed;
   inset: 0;
-  z-index: 15;            /* below #tradeSimulator (20), above header (10) */
+  z-index: 40;            /* above trade preview (20) and header (10) */
   display: block;         /* don't center via flex */
   pointer-events: none;   /* allow clicks only on content panel */
   background: transparent;/* no backdrop for this modal */
@@ -3371,9 +3374,9 @@ img.team-logo.glow[alt="WAS"] {
     position: fixed;
     inset: 0;
     background-color: rgba(0, 0, 0, 0.2);
-    z-index: 9; /* Below header (10) but above main content */
-    -webkit-backdrop-filter: blur(2px);
-    backdrop-filter: blur(2px);
+    z-index: 30; /* Below comparison modal (40) but above content */
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
 }
 
 /* · · ✦ Modal BG, Blur, and Styling · · */


### PR DESCRIPTION
## Summary
- Toggle player comparison modal with Compare button and close it when trade preview collapses
- Clear trade selections when trade preview hides and hide roster grid while comparing
- Restrict game log link to actual player names and enhance comparison overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f62336b4832ea12b664cefb5d175