### PR TITLE
Refine game log modal badges and summary chips

### DIFF
--- a/DH_P2-5.11/scripts/app.js
+++ b/DH_P2-5.11/scripts/app.js
@@ -895,88 +895,130 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
 
             const modalHeader = document.getElementById('modal-header');
+            modalHeader.querySelector('.modal-player-badge')?.remove();
+
             const posTag = document.createElement('div');
             posTag.className = `player-tag modal-pos-tag ${player.pos}`;
             posTag.textContent = player.pos;
-            modalHeader.insertBefore(posTag, modalHeader.firstChild);
+
+            const playerBadge = document.createElement('div');
+            playerBadge.className = 'modal-player-badge';
+            playerBadge.appendChild(posTag);
+
+            const teamKey = (fullPlayer?.team || player.team || 'FA').toUpperCase();
+            const logoKeyMap = { WSH: 'was', WAS: 'was', JAC: 'jax', LA: 'lar' };
+            const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+
+            if (teamKey && teamKey !== 'FA') {
+                const teamLogo = document.createElement('img');
+                teamLogo.className = 'team-logo glow modal-team-logo';
+                teamLogo.src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+                teamLogo.alt = teamKey;
+                teamLogo.width = 19;
+                teamLogo.height = 19;
+                teamLogo.loading = 'lazy';
+                playerBadge.appendChild(teamLogo);
+            } else {
+                const faTag = document.createElement('div');
+                faTag.className = 'team-tag modal-team-logo';
+                faTag.style.backgroundColor = '#64748b';
+                faTag.style.color = 'white';
+                faTag.textContent = 'FA';
+                playerBadge.appendChild(faTag);
+            }
+
+            modalHeader.insertBefore(playerBadge, modalHeader.firstChild);
 
             // Render summary chips
             const summaryChipsContainer = document.getElementById('modal-summary-chips');
-            summaryChipsContainer.innerHTML = `
-                <div class="summary-chip">
-                    <h4>FPTS / PPG</h4>
-                    <div class="chip-values">
-                        <span style="color: ${getRankColor(playerRanks.overallRank)}">${playerRanks.total_pts}</span>
-                        <span class="chip-separator">/</span>
-                        <span style="color: ${getRankColor(playerRanks.ppgOverallRank)}">${playerRanks.ppg}</span>
-                    </div>
-                </div>
-                <div class="summary-chip">
-                    <h4>FPTS RKs</h4>
-                    <div class="chip-values"></div>
-                </div>
-                <div class="summary-chip">
-                    <h4>PPG RKs</h4>
-                    <div class="chip-values"></div>
-                </div>
-            `;
+            summaryChipsContainer.innerHTML = '';
 
-            const fptsValues = summaryChipsContainer.children[1].querySelector('.chip-values');
-            const ppgValues = summaryChipsContainer.children[2].querySelector('.chip-values');
+            const createChip = (nodes, options = {}) => {
+                const chip = document.createElement('div');
+                chip.className = 'summary-chip';
+                chip.setAttribute('role', 'presentation');
+                if (options.title) chip.title = options.title;
+                if (options.ariaLabel) chip.setAttribute('aria-label', options.ariaLabel);
 
-            // Populate FPTS RKs chip
-            if (playerRanks.overallRank === 'NA') {
-                fptsValues.innerHTML = '<span>NA</span>';
-            } else {
-                const overallRankSpan = document.createElement('span');
-                overallRankSpan.style.color = getRankColor(playerRanks.overallRank);
-                overallRankSpan.textContent = `#${playerRanks.overallRank}`;
+                const values = document.createElement('div');
+                values.className = 'chip-values';
+                nodes.forEach(node => values.appendChild(node));
+                chip.appendChild(values);
+                return chip;
+            };
 
-                const separatorSpan = document.createElement('span');
-                separatorSpan.className = 'chip-separator';
-                separatorSpan.textContent = ' / ';
+            const createRankSpan = (rank) => {
+                const span = document.createElement('span');
+                if (typeof rank === 'number') {
+                    span.textContent = `#${rank}`;
+                    span.style.color = getRankColor(rank);
+                } else {
+                    span.textContent = 'NA';
+                }
+                return span;
+            };
 
-                const posRankContainer = document.createElement('span');
-                posRankContainer.className = 'pos-rank-container';
+            const createValueSpan = (value, suffix, rankForColor) => {
+                const span = document.createElement('span');
+                span.textContent = `${value} ${suffix}`.trim();
+                if (typeof rankForColor === 'number') {
+                    span.style.color = getRankColor(rankForColor);
+                }
+                return span;
+            };
 
-                const posTextSpan = document.createElement('span');
-                posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}·`;
+            const createPosRankContent = (rank) => {
+                const container = document.createElement('span');
+                container.className = 'pos-rank-container';
 
-                const posRankSpan = document.createElement('span');
-                posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.posRank);
-                posRankSpan.textContent = playerRanks.posRank;
+                const posSpan = document.createElement('span');
+                posSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
+                posSpan.textContent = player.pos;
 
-                posRankContainer.append(posTextSpan, posRankSpan);
-                fptsValues.append(overallRankSpan, separatorSpan, posRankContainer);
-            }
+                const rankSpan = document.createElement('span');
+                if (typeof rank === 'number') {
+                    rankSpan.textContent = `#${rank}`;
+                    rankSpan.style.color = getGameLogPosRankColor(player.pos, rank);
+                } else {
+                    rankSpan.textContent = 'NA';
+                }
 
-            // Populate PPG RKs chip
-            if (playerRanks.ppgOverallRank === 'NA') {
-                ppgValues.innerHTML = '<span>NA</span>';
-            } else {
-                const overallRankSpan = document.createElement('span');
-                overallRankSpan.style.color = getRankColor(playerRanks.ppgOverallRank);
-                overallRankSpan.textContent = `#${playerRanks.ppgOverallRank}`;
+                container.append(posSpan, rankSpan);
+                return container;
+            };
 
-                const separatorSpan = document.createElement('span');
-                separatorSpan.className = 'chip-separator';
-                separatorSpan.textContent = ' / ';
-
-                const posRankContainer = document.createElement('span');
-                posRankContainer.className = 'pos-rank-container';
-
-                const posTextSpan = document.createElement('span');
-                posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}·`;
-
-                const posRankSpan = document.createElement('span');
-                posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.ppgPosRank);
-                posRankSpan.textContent = `${playerRanks.ppgPosRank}`;
-
-                posRankContainer.append(posTextSpan, posRankSpan);
-                ppgValues.append(overallRankSpan, separatorSpan, posRankContainer);
-            }
+            summaryChipsContainer.append(
+                createChip([
+                    createRankSpan(playerRanks.overallRank)
+                ], {
+                    ariaLabel: 'Overall fantasy points rank'
+                }),
+                createChip([
+                    createValueSpan(playerRanks.total_pts, 'FPTS', playerRanks.overallRank)
+                ], {
+                    ariaLabel: 'Total fantasy points'
+                }),
+                createChip([
+                    createPosRankContent(playerRanks.posRank)
+                ], {
+                    ariaLabel: `${player.pos} fantasy points rank`
+                }),
+                createChip([
+                    createRankSpan(playerRanks.ppgOverallRank)
+                ], {
+                    ariaLabel: 'Overall fantasy points per game rank'
+                }),
+                createChip([
+                    createValueSpan(playerRanks.ppg, 'PPG', playerRanks.ppgOverallRank)
+                ], {
+                    ariaLabel: 'Fantasy points per game'
+                }),
+                createChip([
+                    createPosRankContent(playerRanks.ppgPosRank)
+                ], {
+                    ariaLabel: `${player.pos} fantasy points per game rank`
+                })
+            );
 
             modalBody.innerHTML = ''; // Clear existing content
 

--- a/DH_P2-5.11/styles/styles.css
+++ b/DH_P2-5.11/styles/styles.css
@@ -2467,8 +2467,32 @@ font-weight: 500 !important;
     
     #modal-header {
       text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     }
-    
+
+    .modal-player-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .modal-player-badge .modal-team-logo {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal-player-badge .team-tag {
+      font-size: 0.6rem;
+      font-weight: 600;
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+
     #modal-player-name {
       text-align: center;
       margin-bottom: 1rem;
@@ -2484,8 +2508,35 @@ font-weight: 500 !important;
 
     #modal-summary-chips {
       display: flex;
-      gap: 1rem;
+      gap: 0.45rem;
       flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+      overflow-x: auto;
+      padding: 0.15rem 0;
+      scrollbar-width: none;
+    }
+
+    #modal-summary-chips:hover {
+      scrollbar-width: thin;
+    }
+
+    #modal-summary-chips::-webkit-scrollbar {
+      height: 0;
+    }
+
+    #modal-summary-chips:hover::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    #modal-summary-chips .summary-chip {
+      flex: 0 0 auto;
+    }
+
+    #game-logs-modal .chip-values {
+      gap: 0.2rem;
+      white-space: nowrap;
+      font-weight: 500;
     }
     
     /* · · Summary Chips · · */
@@ -2558,6 +2609,7 @@ font-weight: 500 !important;
     .pos-rank-container {
         display: inline-flex;
         align-items: center;
+        gap: 0.2rem;
     }
 
     .pos-color-QB { color: var(--color-text-secondary);}


### PR DESCRIPTION
## Summary
- show the player's team logo beside the position chip in the game log modal header
- break the game log summary into individual FPTS and PPG chips with clearer labeling and colors
- adjust modal styling so the chips stay in a single row with tighter spacing across viewports

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c86bd79f08832ea7faede5164e2a5c