### PR TITLE
Refine game log modal header details

### DIFF
--- a/DH_P2-5.11/scripts/app.js
+++ b/DH_P2-5.11/scripts/app.js
@@ -872,8 +872,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             modalPlayerName.textContent = `${playerName}`;
             document.getElementById('modal-summary-chips').innerHTML = ''; // Clear previous chips
-            const existingTag = document.querySelector('.modal-pos-tag');
-            if(existingTag) existingTag.remove();
+            const existingPosGroup = document.querySelector('.modal-pos-group');
+            if (existingPosGroup) existingPosGroup.remove();
             modalBody.innerHTML = '<p class="text-center p-4">Loading game logs...</p>';
 
             if (state.isGameLogModalOpenFromComparison) {
@@ -895,88 +895,155 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
 
             const modalHeader = document.getElementById('modal-header');
+            const existingPosGroup = modalHeader.querySelector('.modal-pos-group');
+            if (existingPosGroup) existingPosGroup.remove();
+
+            const posGroup = document.createElement('div');
+            posGroup.className = 'modal-pos-group';
+
             const posTag = document.createElement('div');
             posTag.className = `player-tag modal-pos-tag ${player.pos}`;
             posTag.textContent = player.pos;
-            modalHeader.insertBefore(posTag, modalHeader.firstChild);
+            posGroup.appendChild(posTag);
 
-            // Render summary chips
+            const teamKey = (player.team || 'FA').toUpperCase();
+            if (teamKey && teamKey !== 'FA') {
+                const logoKeyMap = { WSH: 'was', WAS: 'was', JAC: 'jax', LA: 'lar' };
+                const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+                const teamLogo = document.createElement('img');
+                teamLogo.className = 'team-logo glow modal-team-logo';
+                teamLogo.src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+                teamLogo.alt = teamKey;
+                teamLogo.width = 22;
+                teamLogo.height = 22;
+                teamLogo.loading = 'lazy';
+                posGroup.appendChild(teamLogo);
+            } else {
+                const faTag = document.createElement('div');
+                faTag.className = 'modal-team-tag';
+                faTag.textContent = 'FA';
+                posGroup.appendChild(faTag);
+            }
+
+            modalHeader.insertBefore(posGroup, modalHeader.firstChild);
+
             const summaryChipsContainer = document.getElementById('modal-summary-chips');
-            summaryChipsContainer.innerHTML = `
-                <div class="summary-chip">
-                    <h4>FPTS / PPG</h4>
-                    <div class="chip-values">
-                        <span style="color: ${getRankColor(playerRanks.overallRank)}">${playerRanks.total_pts}</span>
-                        <span class="chip-separator">/</span>
-                        <span style="color: ${getRankColor(playerRanks.ppgOverallRank)}">${playerRanks.ppg}</span>
-                    </div>
-                </div>
-                <div class="summary-chip">
-                    <h4>FPTS RKs</h4>
-                    <div class="chip-values"></div>
-                </div>
-                <div class="summary-chip">
-                    <h4>PPG RKs</h4>
-                    <div class="chip-values"></div>
-                </div>
-            `;
+            summaryChipsContainer.innerHTML = '';
 
-            const fptsValues = summaryChipsContainer.children[1].querySelector('.chip-values');
-            const ppgValues = summaryChipsContainer.children[2].querySelector('.chip-values');
+            const toNumber = (value) => {
+                if (typeof value === 'number' && Number.isFinite(value)) return value;
+                const parsed = parseInt(value, 10);
+                return Number.isFinite(parsed) ? parsed : null;
+            };
 
-            // Populate FPTS RKs chip
-            if (playerRanks.overallRank === 'NA') {
-                fptsValues.innerHTML = '<span>NA</span>';
-            } else {
-                const overallRankSpan = document.createElement('span');
-                overallRankSpan.style.color = getRankColor(playerRanks.overallRank);
-                overallRankSpan.textContent = `#${playerRanks.overallRank}`;
+            const createChip = (titleText, tooltip) => {
+                const chip = document.createElement('div');
+                chip.className = 'summary-chip';
+                if (!titleText) {
+                    chip.classList.add('no-title');
+                } else {
+                    const titleEl = document.createElement('h4');
+                    titleEl.textContent = titleText;
+                    chip.appendChild(titleEl);
+                }
+                if (tooltip) chip.title = tooltip;
+                const valuesEl = document.createElement('div');
+                valuesEl.className = 'chip-values';
+                chip.appendChild(valuesEl);
+                return { chip, valuesEl };
+            };
 
-                const separatorSpan = document.createElement('span');
-                separatorSpan.className = 'chip-separator';
-                separatorSpan.textContent = ' / ';
+            const appendRankChip = (rankValue, options = {}) => {
+                const { title, tooltip, prefix = '#', color } = options;
+                const { chip, valuesEl } = createChip(title, tooltip);
+                if (rankValue === 'NA' || rankValue === 'N/A') {
+                    const span = document.createElement('span');
+                    span.textContent = 'NA';
+                    valuesEl.appendChild(span);
+                } else {
+                    const span = document.createElement('span');
+                    span.textContent = `${prefix}${rankValue}`;
+                    if (color) span.style.color = color;
+                    valuesEl.appendChild(span);
+                }
+                summaryChipsContainer.appendChild(chip);
+            };
 
-                const posRankContainer = document.createElement('span');
-                posRankContainer.className = 'pos-rank-container';
+            const appendValueChip = (value, options = {}) => {
+                const { title, tooltip, suffix = '', color } = options;
+                const { chip, valuesEl } = createChip(title, tooltip);
+                const span = document.createElement('span');
+                const hasValue = value !== undefined && value !== null && value !== 'N/A' && value !== 'NA';
+                span.textContent = hasValue ? `${value}${suffix}` : '—';
+                if (color) span.style.color = color;
+                valuesEl.appendChild(span);
+                summaryChipsContainer.appendChild(chip);
+            };
 
-                const posTextSpan = document.createElement('span');
-                posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}·`;
+            const appendPosRankChip = (rankValue, options = {}) => {
+                const { title, tooltip, posLabel, color } = options;
+                const { chip, valuesEl } = createChip(title, tooltip);
+                if (rankValue === 'NA' || rankValue === 'N/A') {
+                    const span = document.createElement('span');
+                    span.textContent = 'NA';
+                    valuesEl.appendChild(span);
+                } else {
+                    const container = document.createElement('span');
+                    container.className = 'pos-rank-container';
 
-                const posRankSpan = document.createElement('span');
-                posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.posRank);
-                posRankSpan.textContent = playerRanks.posRank;
+                    const posSpan = document.createElement('span');
+                    posSpan.className = 'chip-pos-rank-label';
+                    if (posLabel) posSpan.classList.add(`pos-color-${posLabel}`);
+                    posSpan.textContent = posLabel || '?';
 
-                posRankContainer.append(posTextSpan, posRankSpan);
-                fptsValues.append(overallRankSpan, separatorSpan, posRankContainer);
-            }
+                    const rankSpan = document.createElement('span');
+                    rankSpan.textContent = `#${rankValue}`;
+                    if (color) rankSpan.style.color = color;
 
-            // Populate PPG RKs chip
-            if (playerRanks.ppgOverallRank === 'NA') {
-                ppgValues.innerHTML = '<span>NA</span>';
-            } else {
-                const overallRankSpan = document.createElement('span');
-                overallRankSpan.style.color = getRankColor(playerRanks.ppgOverallRank);
-                overallRankSpan.textContent = `#${playerRanks.ppgOverallRank}`;
+                    container.append(posSpan, rankSpan);
+                    valuesEl.appendChild(container);
+                }
+                summaryChipsContainer.appendChild(chip);
+            };
 
-                const separatorSpan = document.createElement('span');
-                separatorSpan.className = 'chip-separator';
-                separatorSpan.textContent = ' / ';
+            const overallRankNumber = toNumber(playerRanks.overallRank);
+            const posRankNumber = toNumber(playerRanks.posRank);
+            const ppgOverallRankNumber = toNumber(playerRanks.ppgOverallRank);
+            const ppgPosRankNumber = toNumber(playerRanks.ppgPosRank);
 
-                const posRankContainer = document.createElement('span');
-                posRankContainer.className = 'pos-rank-container';
+            appendRankChip(playerRanks.overallRank, {
+                tooltip: 'Overall Fantasy Points Rank',
+                color: overallRankNumber !== null ? getRankColor(overallRankNumber) : null
+            });
 
-                const posTextSpan = document.createElement('span');
-                posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}·`;
+            appendValueChip(playerRanks.total_pts, {
+                tooltip: 'Season Fantasy Points Total',
+                suffix: ' FPTS',
+                color: overallRankNumber !== null ? getRankColor(overallRankNumber) : null
+            });
 
-                const posRankSpan = document.createElement('span');
-                posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.ppgPosRank);
-                posRankSpan.textContent = `${playerRanks.ppgPosRank}`;
+            appendPosRankChip(playerRanks.posRank, {
+                tooltip: `${player.pos} Fantasy Points Rank`,
+                posLabel: player.pos,
+                color: posRankNumber !== null ? getGameLogPosRankColor(player.pos, posRankNumber) : null
+            });
 
-                posRankContainer.append(posTextSpan, posRankSpan);
-                ppgValues.append(overallRankSpan, separatorSpan, posRankContainer);
-            }
+            appendRankChip(playerRanks.ppgOverallRank, {
+                tooltip: 'Overall Points Per Game Rank',
+                color: ppgOverallRankNumber !== null ? getRankColor(ppgOverallRankNumber) : null
+            });
+
+            appendValueChip(playerRanks.ppg, {
+                tooltip: 'Fantasy Points Per Game',
+                suffix: ' PPG',
+                color: ppgOverallRankNumber !== null ? getRankColor(ppgOverallRankNumber) : null
+            });
+
+            appendPosRankChip(playerRanks.ppgPosRank, {
+                tooltip: `${player.pos} Points Per Game Rank`,
+                posLabel: player.pos,
+                color: ppgPosRankNumber !== null ? getGameLogPosRankColor(player.pos, ppgPosRankNumber) : null
+            });
 
             modalBody.innerHTML = ''; // Clear existing content
 

--- a/DH_P2-5.11/styles/styles.css
+++ b/DH_P2-5.11/styles/styles.css
@@ -2315,9 +2315,7 @@ font-weight: 500 !important;
     
     /* · · Pos Tags · · */
     .modal-pos-tag {
-        position: absolute;
-        top: 0.70rem;
-        left: 0.75rem;
+        position: relative;
         line-height: 0.9rem;
         font-size: 0.9rem;
         padding: 4px 8px;
@@ -2326,6 +2324,9 @@ font-weight: 500 !important;
         border: 1px solid rgba(250, 250, 250, 0.12);
         border-radius: 1rem;
         box-shadow: 0 8px 32px rgba(31, 38, 135, 0.2), inset 0 4px 20px rgba(255, 255, 255, 0.05);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     
      .modal-pos-tag::after {
@@ -2466,6 +2467,7 @@ font-weight: 500 !important;
     }
     
     #modal-header {
+      position: relative;
       text-align: center;
     }
     
@@ -2478,14 +2480,48 @@ font-weight: 500 !important;
       display: flex;
       justify-content: center;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.35rem;
       margin-bottom: 0.75rem;
+      padding: 0 0.35rem;
     }
 
     #modal-summary-chips {
       display: flex;
-      gap: 1rem;
+      gap: 0.4rem;
       flex-wrap: nowrap;
+      justify-content: center;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+
+    #modal-summary-chips::-webkit-scrollbar {
+      display: none;
+    }
+
+    .modal-pos-group {
+      position: absolute;
+      top: 0.7rem;
+      left: 0.75rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      z-index: 2;
+    }
+
+    .modal-team-tag {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 22px;
+      padding: 0 0.45rem;
+      border-radius: 999px;
+      background-color: #64748b;
+      color: #fff;
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      line-height: 1;
     }
     
     /* · · Summary Chips · · */
@@ -2518,9 +2554,13 @@ font-weight: 500 !important;
     }
 
      .summary-chip {
-      padding: 0.27rem 0.6rem;
+      padding: 0.32rem 0.55rem;
       text-align: center;
       min-width: auto;
+    }
+
+    .summary-chip.no-title {
+      padding: 0.32rem 0.5rem;
     }
         
     .summary-chip h4 {
@@ -2537,10 +2577,11 @@ font-weight: 500 !important;
         display: flex;
         justify-content: center;
         align-items: center;
-        gap: 0.25rem;
+        gap: 0.2rem;
         font-size: 0.85rem;
         color: var(--color-text-primary);
         font-weight: 400;
+        white-space: nowrap;
     }
     
     .chip-separator {
@@ -2550,14 +2591,17 @@ font-weight: 500 !important;
     }
 
     .chip-pos-rank-label {
-        font-size: 0.85em;
-        font-weight: 400;
-        margin-top: 0.05rem;
+        font-size: 0.8em;
+        font-weight: 500;
+        margin-top: 0;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
     }
 
     .pos-rank-container {
         display: inline-flex;
         align-items: center;
+        gap: 0.25rem;
     }
 
     .pos-color-QB { color: var(--color-text-secondary);}
@@ -3113,6 +3157,13 @@ img.team-logo.glow{
     drop-shadow(0 0 var(--glow-r1) var(--team-glow))
     drop-shadow(0 0 var(--glow-r2) var(--team-glow))
     drop-shadow(0 0 var(--glow-r3) var(--team-glow));
+}
+
+img.team-logo.modal-team-logo {
+  width:22px;
+  height:22px;
+  border-radius:4px;
+  object-fit:contain;
 }
 
 


### PR DESCRIPTION
## Summary
- add the team logo/FA badge beside the modal position chip when viewing a game log
- replace the combined summary chips with discrete FPTS/PPG rank, value, and positional chips while keeping conditional colors
- tweak modal chip styling so the new layout stays in a single row across breakpoints

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c86bd79f08832ea7faede5164e2a5c