### PR TITLE
Display season stat ranks in game logs and comparisons

### DIFF
--- a/DH_P2-5.16/scripts/app.js
+++ b/DH_P2-5.16/scripts/app.js
@@ -117,7 +117,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         });
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonStatRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -127,7 +127,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const API_BASE = 'https://api.sleeper.app/v1';
         const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
         const PLAYER_STATS_SHEET_ID = '1i-cKqSfYw0iFiV9S-wBw8lwZePwXZ7kcaWMdnaMTHDs';
-        const PLAYER_STATS_SHEETS = { season: 'SZN', weeks: { 1: 'WK1', 2: 'WK2' } };
+        const PLAYER_STATS_SHEETS = { season: 'SZN', seasonRanks: 'SZN_RKs', weeks: { 1: 'WK1', 2: 'WK2' } };
         const TAG_COLORS = { QB:"var(--pos-qb)", RB:"var(--pos-rb)", WR:"var(--pos-wr)", TE:"var(--pos-te)", BN:"var(--pos-bn)", TX:"var(--pos-tx)", FLX: "var(--pos-flx)", SFLX: "var(--pos-sflx)" };
         const STARTER_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#1a2d4e", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
@@ -766,14 +766,16 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             if (state.statsSheetsLoaded) return;
             try {
                 const seasonPromise = fetch(`https://docs.google.com/spreadsheets/d/${PLAYER_STATS_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${PLAYER_STATS_SHEETS.season}`).then(res => res.text());
+                const seasonRankPromise = fetch(`https://docs.google.com/spreadsheets/d/${PLAYER_STATS_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${PLAYER_STATS_SHEETS.seasonRanks}`).then(res => res.text());
                 const weeklyPromises = Object.entries(PLAYER_STATS_SHEETS.weeks).map(async ([week, sheetName]) => {
                     const csv = await fetch(`https://docs.google.com/spreadsheets/d/${PLAYER_STATS_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${sheetName}`).then(res => res.text());
                     return { week: Number(week), csv };
                 });
 
-                const [seasonCsv, ...weeklyCsvs] = await Promise.all([seasonPromise, ...weeklyPromises]);
+                const [seasonCsv, seasonRankCsv, ...weeklyCsvs] = await Promise.all([seasonPromise, seasonRankPromise, ...weeklyPromises]);
 
                 state.playerSeasonStats = parseSeasonStatsCsv(seasonCsv);
+                state.playerSeasonStatRanks = parseSeasonStatsCsv(seasonRankCsv);
                 state.seasonRankCache = computeSeasonRankings(state.playerSeasonStats);
                 const weeklyStats = {};
                 weeklyCsvs.forEach(({ week, csv }) => {
@@ -785,6 +787,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             } catch (error) {
                 console.error('Failed to fetch player stats from sheet.', error);
                 state.playerSeasonStats = {};
+                state.playerSeasonStatRanks = {};
                 state.playerWeeklyStats = {};
                 state.seasonRankCache = null;
                 state.statsSheetsLoaded = false;
@@ -840,6 +843,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             'FPT_PPR': 'fpts_ppr',
             'FPTS_PPR': 'fpts_ppr',
             'PRK_PPR': 'pos_rank_ppr'
+        };
+
+        const STAT_KEY_TO_RANK_KEY = {
+            fpts: 'fpts_ppr'
         };
 
         function parseSeasonStatsCsv(csvText) {
@@ -1493,6 +1500,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 footerRow.appendChild(totalTh);
 
                 const seasonTotals = state.playerSeasonStats?.[player.id] || null;
+                const seasonRanks = state.playerSeasonStatRanks?.[player.id] || null;
                 const aggregatedTotals = {};
                 const snapPctValues = [];
                 const statValueCounts = {};
@@ -1612,7 +1620,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         const totalValue = seasonTotals && typeof seasonTotals[key] === 'number' ? seasonTotals[key] : (aggregatedTotals[key] || 0);
                         displayValue = Number.isInteger(totalValue) ? String(totalValue) : Number(totalValue || 0).toFixed(2).replace(/\.00$/, '');
                     }
-                    td.textContent = displayValue;
+
+                    const rankKey = STAT_KEY_TO_RANK_KEY[key] || key;
+                    const rankValue = seasonRanks ? seasonRanks[rankKey] : null;
+                    td.textContent = combineValueWithRank(displayValue, rankValue);
                     footerRow.appendChild(td);
                 }
                 tfoot.appendChild(footerRow);
@@ -1829,12 +1840,13 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             for (const statKey of orderedStatKeys) {
                 if (statLabels[statKey]) {
                     const row = document.createElement('tr');
-                    row.innerHTML = `<td>${statLabels[statKey]}</td>`;
+                    row.innerHTML = `<td>${statLabels[statKey]}${RANK_SUPERSCRIPT_LABEL}</td>`;
 
                     let maxVal = -Infinity;
                     let maxIndices = [];
                     const values = [];
                     const displayValues = [];
+                    const rankValues = [];
 
                     for (let i = 0; i < players.length; i++) {
                         const player = players[i];
@@ -2010,6 +2022,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                         values.push(calculatedValue);
                         displayValues.push(displayValue);
+                        const rankKey = STAT_KEY_TO_RANK_KEY[statKey] || statKey;
+                        const seasonRanks = state.playerSeasonStatRanks?.[player.id] || null;
+                        rankValues.push(seasonRanks ? seasonRanks[rankKey] : null);
 
                         if (calculatedValue > maxVal) {
                             maxVal = calculatedValue;
@@ -2021,7 +2036,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                     displayValues.forEach((val, i) => {
                         const td = document.createElement('td');
-                        td.textContent = val;
+                        td.textContent = combineValueWithRank(val, rankValues[i]);
                         if (val !== 'N/A') {
                             if (maxIndices.length > 1 && maxIndices.includes(i)) {
                                 td.style.color = '#8ab4f8'; // Blue for ties
@@ -2678,6 +2693,53 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
             }
             return totalPoints;
+        }
+
+        const SUPERSCRIPT_MAP = {
+            '0': '⁰',
+            '1': '¹',
+            '2': '²',
+            '3': '³',
+            '4': '⁴',
+            '5': '⁵',
+            '6': '⁶',
+            '7': '⁷',
+            '8': '⁸',
+            '9': '⁹',
+            '+': '⁺',
+            '-': '⁻',
+            '.': '.',
+            '/': '/',
+            'R': 'ᴿ',
+            'A': 'ᴬ',
+            'N': 'ᴺ',
+            'K': 'ᴷ'
+        };
+
+        function toSuperscriptString(text) {
+            if (!text) return '';
+            let result = '';
+            for (const char of text) {
+                const mapped = SUPERSCRIPT_MAP[char] ?? SUPERSCRIPT_MAP[char.toUpperCase()] ?? char;
+                result += mapped;
+            }
+            return result;
+        }
+
+        const NA_SUPERSCRIPT = '⁽ᴺᴬ⁾';
+        const RANK_SUPERSCRIPT_LABEL = `⁽${toSuperscriptString('RANK')}⁾`;
+
+        function formatRankSuperscript(value) {
+            if (value === null || value === undefined) return NA_SUPERSCRIPT;
+            const trimmed = String(value).trim();
+            if (!trimmed) return NA_SUPERSCRIPT;
+            if (trimmed.toUpperCase() === 'NA') return NA_SUPERSCRIPT;
+            return `⁽${toSuperscriptString(trimmed)}⁾`;
+        }
+
+        function combineValueWithRank(value, rankValue) {
+            const base = value === null || value === undefined ? '' : String(value);
+            return `${base}${formatRankSuperscript(rankValue)}`;
         }
 
         function formatPercentage(value, decimals = 1) {


### PR DESCRIPTION
## Summary
- load season rank data from the SZN_RKs sheet and store it with the existing season stats cache
- add superscript formatting helpers and append season ranks to game log totals and player comparison rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc65a68dcc832e8718ef30c00ad127