### PR TITLE
Revise player compare modal header layout

### DIFF
--- a/DH_P2-5.178/scripts/app.js
+++ b/DH_P2-5.178/scripts/app.js
@@ -1804,15 +1804,50 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const headerContainer = document.createElement('div');
                 headerContainer.className = 'player-name-header-container';
 
-                headerContainer.innerHTML = `
-                    <div class="player-name-header">${playerName}<br><span class="game-log-link">Game Log</span></div>
-                `;
+                const nameHeader = document.createElement('div');
+                nameHeader.className = 'player-name-header';
 
-                const gameLogLink = headerContainer.querySelector('.game-log-link');
-                gameLogLink.onclick = () => {
+                const nameLink = document.createElement('span');
+                nameLink.className = 'comparison-player-name-link';
+                nameLink.textContent = playerName;
+                nameLink.tabIndex = 0;
+                nameLink.addEventListener('click', () => {
                     state.isGameLogModalOpenFromComparison = true;
                     handlePlayerNameClick(player);
-                };
+                });
+                nameLink.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        state.isGameLogModalOpenFromComparison = true;
+                        handlePlayerNameClick(player);
+                    }
+                });
+
+                nameHeader.appendChild(nameLink);
+                headerContainer.appendChild(nameHeader);
+
+                const tagRow = document.createElement('div');
+                tagRow.className = 'player-info-tags';
+
+                const posTag = document.createElement('div');
+                posTag.className = `player-tag modal-pos-tag comparison-pos-tag ${player.pos}`;
+                posTag.textContent = player.pos;
+                tagRow.appendChild(posTag);
+
+                const teamKey = (player.team || 'FA').toUpperCase();
+                const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
+                const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+                const src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+
+                const teamLogoChip = document.createElement('div');
+                teamLogoChip.className = 'player-tag modal-team-logo-chip comparison-team-logo-chip';
+                teamLogoChip.dataset.team = teamKey;
+                teamLogoChip.innerHTML = (player.team && player.team !== 'FA')
+                    ? `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="20" height="20" loading="lazy">`
+                    : `<span>FA</span>`;
+                tagRow.appendChild(teamLogoChip);
+
+                headerContainer.appendChild(tagRow);
 
                 playerNamesRow.appendChild(headerContainer);
             });
@@ -1883,7 +1918,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
                 const th = document.createElement('th');
                 th.className = 'player-header';
-                th.innerHTML = `<h4>${playerName}</h4><span class="player-pos-team">${player.pos} - ${fullPlayer.team || 'FA'}</span>`;
+                th.innerHTML = `<h4>${playerName}</h4>`;
                 tr.appendChild(th);
             });
             thead.appendChild(tr);

--- a/DH_P2-5.178/styles/styles.css
+++ b/DH_P2-5.178/styles/styles.css
@@ -2881,6 +2881,45 @@ font-weight: 500 !important;
         color: var(--color-text-primary);
         line-height: 1.1;
     }
+
+    #player-comparison-modal .comparison-player-name-link {
+        color: inherit;
+        cursor: pointer;
+        text-decoration: none;
+        outline: none;
+    }
+
+    #player-comparison-modal .comparison-player-name-link:hover,
+    #player-comparison-modal .comparison-player-name-link:focus {
+        color: var(--color-text-secondary);
+    }
+
+    #player-comparison-modal .player-info-tags {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.4rem;
+        margin-top: 0.35rem;
+    }
+
+    #player-comparison-modal .comparison-pos-tag {
+        font-size: 0.75rem;
+        line-height: 0.75rem;
+        padding: 3px 7px;
+    }
+
+    #player-comparison-modal .comparison-team-logo-chip {
+        padding: 2px 6px;
+    }
+
+    #player-comparison-modal .comparison-team-logo-chip img.team-logo {
+        width: 20px;
+        height: 20px;
+    }
+
+    #player-comparison-modal .comparison-team-logo-chip span {
+        font-size: 0.7rem;
+    }
     
     #close-comparison-key {
         cursor: pointer;
@@ -2901,7 +2940,7 @@ font-weight: 500 !important;
         justify-content: center;
         gap: 1rem;
         flex-wrap: wrap;
-        padding: 0.5rem 0;
+        padding: 0.35rem 0;
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
@@ -2971,7 +3010,7 @@ font-weight: 500 !important;
         
         /* · · Summary Chips · · */
     #player-comparison-modal .summary-chip {
-        padding: 0.3rem 0.9rem; /* Further reduced padding */
+        padding: 0.22rem 0.85rem; /* Further reduced padding */
         text-align: center;
         min-width: auto;
         position: relative;


### PR DESCRIPTION
## Summary
- link player names in the comparison modal directly to game logs and display compact position and team tags beneath each name
- remove the position/team label from table headers and tighten the comparison summary chip spacing to free room for the stats table

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68ccf7c4f8ec832e9552569e737cc430