### PR TITLE
Fix compare modal game log link and adjust layout spacing

### DIFF
--- a/DH_P2-5.178/scripts/app.js
+++ b/DH_P2-5.178/scripts/app.js
@@ -1350,8 +1350,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- UI Rendering ---
         async function handlePlayerNameClick(player) {
-            const fullPlayer = state.players[player.id];
-            const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
+            if (!player) return;
+
+            const playerId = player.id || player.player_id;
+            if (!playerId) return;
+
+            const fullPlayer = state.players[playerId];
+            const fallbackName = player.name || player.label || player.full_name || player.fullName || 'Player';
+            const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}`.trim() : fallbackName;
 
             modalPlayerName.textContent = `${playerName}`;
             document.getElementById('modal-summary-chips').innerHTML = ''; // Clear previous chips
@@ -1364,38 +1370,51 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
             openModal();
 
-            const gameLogs = await fetchGameLogs(player.id);
-            const playerRanks = calculatePlayerStatsAndRanks(player.id);
-            renderGameLogs(gameLogs, player, playerRanks);
+            const enrichedPlayer = {
+                ...player,
+                id: playerId,
+                name: playerName,
+                team: player.team || fullPlayer?.team || fullPlayer?.metadata?.team,
+                pos: player.pos || fullPlayer?.position || fullPlayer?.fantasy_positions?.[0],
+            };
+            const gameLogs = await fetchGameLogs(playerId);
+            const playerRanks = calculatePlayerStatsAndRanks(playerId);
+            renderGameLogs(gameLogs, enrichedPlayer, playerRanks, fullPlayer);
         }
 
-        function renderGameLogs(gameLogs, player, playerRanks) {
+        function renderGameLogs(gameLogs, player, playerRanks, fullPlayerOverride = null) {
             const league = state.leagues.find(l => l.league_id === state.currentLeagueId);
             if (!league) return;
             const scoringSettings = league.scoring_settings;
 
-            const fullPlayer = state.players[player.id];
-            const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
+            const playerId = player?.id || player?.player_id;
+            const fullPlayer = fullPlayerOverride || (playerId ? state.players[playerId] : null);
+            const fallbackName = player.name || player.label || player.full_name || player.fullName || 'Player';
+            const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}`.trim() : fallbackName;
 
             const modalHeader = document.getElementById('modal-header');
             const headerContainer = document.createElement('div');
             headerContainer.className = 'modal-header-left-container';
 
             const posTag = document.createElement('div');
-            posTag.className = `player-tag modal-pos-tag ${player.pos}`;
-            posTag.textContent = player.pos;
+            const primaryPos = (fullPlayer?.position || fullPlayer?.fantasy_positions?.[0] || player.pos || 'FA');
+            posTag.className = `player-tag modal-pos-tag ${primaryPos}`;
+            posTag.textContent = primaryPos;
             headerContainer.appendChild(posTag);
 
-            const teamKey = (player.team || 'FA').toUpperCase();
+            const teamSource = player.team || fullPlayer?.team || fullPlayer?.metadata?.team || 'FA';
+            const teamKey = (teamSource || 'FA').toUpperCase();
             const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
             const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
             const src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
             const teamLogoChip = document.createElement('div');
             teamLogoChip.className = 'player-tag modal-team-logo-chip';
-            teamLogoChip.dataset.team = teamKey;
-            teamLogoChip.innerHTML = (player.team && player.team !== 'FA')
-              ? `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="24" height="24" loading="lazy">`
-              : `<span>FA</span>`;
+            if (teamKey && teamKey !== 'FA') {
+                teamLogoChip.dataset.team = teamKey;
+                teamLogoChip.innerHTML = `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="24" height="24" loading="lazy">`;
+            } else {
+                teamLogoChip.innerHTML = '<span>FA</span>';
+            }
             headerContainer.appendChild(teamLogoChip);
             modalHeader.insertBefore(headerContainer, modalHeader.firstChild);
 
@@ -1778,10 +1797,23 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             openComparisonModal();
 
             const playerData = await Promise.all(selectedPlayersWithTeams.map(async (player) => {
+                const basePlayer = state.players[player.id] || null;
+                const primaryPosition = basePlayer?.position || basePlayer?.fantasy_positions?.[0] || player.pos || 'FA';
+                const teamAbbr = basePlayer?.team || basePlayer?.metadata?.team || player.team || 'FA';
+                const displayName = basePlayer ? `${basePlayer.first_name} ${basePlayer.last_name}`.trim() : (player.name || player.label || '');
+
                 const gameLogs = await fetchGameLogs(player.id);
                 const playerRanks = calculatePlayerStatsAndRanks(player.id);
                 const seasonStats = state.playerSeasonStats?.[player.id] || null;
-                return { ...player, gameLogs, seasonStats, ...playerRanks };
+                return {
+                    ...player,
+                    name: displayName,
+                    pos: primaryPosition,
+                    team: teamAbbr,
+                    gameLogs,
+                    seasonStats,
+                    ...playerRanks,
+                };
             }));
 
             renderPlayerComparison(playerData);
@@ -1799,20 +1831,50 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             playerNamesRow.className = 'player-names-row';
             players.forEach(player => {
                 const fullPlayer = state.players[player.id];
-                const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
+                const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : (player.name || player.label);
 
                 const headerContainer = document.createElement('div');
                 headerContainer.className = 'player-name-header-container';
 
-                headerContainer.innerHTML = `
-                    <div class="player-name-header">${playerName}<br><span class="game-log-link">Game Log</span></div>
-                `;
+                const nameHeader = document.createElement('div');
+                nameHeader.className = 'player-name-header';
 
-                const gameLogLink = headerContainer.querySelector('.game-log-link');
-                gameLogLink.onclick = () => {
+                const nameButton = document.createElement('button');
+                nameButton.type = 'button';
+                nameButton.className = 'player-name-header-link';
+                nameButton.textContent = playerName;
+                nameButton.onclick = () => {
                     state.isGameLogModalOpenFromComparison = true;
                     handlePlayerNameClick(player);
                 };
+
+                const tagsRow = document.createElement('div');
+                tagsRow.className = 'player-header-tags';
+
+                const resolvedPosition = fullPlayer?.position || fullPlayer?.fantasy_positions?.[0] || player.pos || 'FA';
+                const posTag = document.createElement('div');
+                posTag.className = `player-tag modal-pos-tag ${resolvedPosition}`;
+                posTag.textContent = resolvedPosition;
+
+                const teamKey = (player.team || fullPlayer?.team || fullPlayer?.metadata?.team || 'FA').toUpperCase();
+                const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
+                const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+                const src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+                const teamLogoChip = document.createElement('div');
+                teamLogoChip.className = 'player-tag modal-team-logo-chip';
+                if (teamKey && teamKey !== 'FA') {
+                    teamLogoChip.dataset.team = teamKey;
+                    teamLogoChip.innerHTML = `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="20" height="20" loading="lazy">`;
+                } else {
+                    teamLogoChip.innerHTML = '<span>FA</span>';
+                }
+
+                tagsRow.appendChild(posTag);
+                tagsRow.appendChild(teamLogoChip);
+
+                nameHeader.appendChild(nameButton);
+                nameHeader.appendChild(tagsRow);
+                headerContainer.appendChild(nameHeader);
 
                 playerNamesRow.appendChild(headerContainer);
             });
@@ -1883,7 +1945,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
                 const th = document.createElement('th');
                 th.className = 'player-header';
-                th.innerHTML = `<h4>${playerName}</h4><span class="player-pos-team">${player.pos} - ${fullPlayer.team || 'FA'}</span>`;
+                th.innerHTML = `<h4>${playerName}</h4>`;
                 tr.appendChild(th);
             });
             thead.appendChild(tr);

--- a/DH_P2-5.178/styles/styles.css
+++ b/DH_P2-5.178/styles/styles.css
@@ -2713,7 +2713,7 @@ font-weight: 500 !important;
     align-items: center;
     justify-content: center;
     gap: 0.2em;
-    margin-top: 0.35rem;
+    margin-top: 0.5rem;
     margin-bottom: 0.15rem;
     font-size: 0.75rem;
     line-height:0.75rem;
@@ -2860,7 +2860,7 @@ font-weight: 500 !important;
     .player-comparison-container {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.3rem;
         flex: 1;
         min-height: 0;
     }
@@ -2880,6 +2880,55 @@ font-weight: 500 !important;
         font-weight: 700;
         color: var(--color-text-primary);
         line-height: 1.1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.3rem;
+    }
+
+    .player-name-header-link {
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        padding: 0;
+        text-decoration: none;
+        transition: color 0.2s ease, text-decoration-color 0.2s ease;
+    }
+
+    .player-name-header-link:hover,
+    .player-name-header-link:focus-visible {
+        color: var(--color-accent-primary);
+        text-decoration: underline;
+        outline: none;
+    }
+
+    .player-header-tags {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.35rem;
+        margin-top: 0.1rem;
+    }
+
+    .player-header-tags .modal-pos-tag {
+        font-size: 0.75rem;
+        padding: 3px 6px;
+        line-height: 0.85rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip {
+        padding: 1px 5px;
+    }
+
+    .player-header-tags .modal-team-logo-chip span {
+        font-size: 0.7rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip img.team-logo {
+        width: 18px;
+        height: 18px;
     }
     
     #close-comparison-key {
@@ -2899,9 +2948,9 @@ font-weight: 500 !important;
     .comparison-summary-chips-row {
         display: flex;
         justify-content: center;
-        gap: 1rem;
+        gap: 0.75rem;
         flex-wrap: wrap;
-        padding: 0.5rem 0;
+        padding: 0.35rem 0;
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
@@ -2921,7 +2970,7 @@ font-weight: 500 !important;
     .summary-chips-container {
         display: flex;
         flex-direction: column;
-        gap: 0.25rem;
+        gap: 0.2rem;
     }
     
     /* · · Player Comp Table · · */
@@ -2971,7 +3020,7 @@ font-weight: 500 !important;
         
         /* · · Summary Chips · · */
     #player-comparison-modal .summary-chip {
-        padding: 0.3rem 0.9rem; /* Further reduced padding */
+        padding: 0.24rem 0.85rem; /* Further reduced padding */
         text-align: center;
         min-width: auto;
         position: relative;
@@ -2993,10 +3042,10 @@ font-weight: 500 !important;
         font-size: 0.7rem;
         font-weight: 700;
         color: var(--color-text-secondary);
-        margin-bottom: 0.1rem;
+        margin-bottom: 0.05rem;
         text-transform: uppercase;
         border-bottom: 1px solid var(--color-panel-border);
-        padding-bottom: 0.1rem;
+        padding-bottom: 0.08rem;
         gap: 0.5rem;
     }
 #player-comparison-modal .summary-chip .chip-separator {
@@ -3190,7 +3239,8 @@ font-weight: 500 !important;
     }
 
     #player-comparison-modal .comparison-summary-chips-row {
-        gap: 0.5rem;
+        gap: 0.4rem;
+        padding: 0.25rem 0;
     }
 
     #player-comparison-modal .summary-chips-container {


### PR DESCRIPTION
## Summary
- enrich comparison modal player data so clicking a name opens the correct game log with accurate position and team context
- reuse the roster modal tag styling in both the comparison header and game log modal with updated positioning
- nudge the stats key button downward and tighten container spacing so the table gains the freed vertical space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf7c4f8ec832e9552569e737cc430