### PR TITLE
Fix comparison modal game log launch and layout tweaks

### DIFF
--- a/DH_P2-5.178/scripts/app.js
+++ b/DH_P2-5.178/scripts/app.js
@@ -511,7 +511,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const teamName = assetRow.closest('.roster-column')?.dataset.teamName;
             if (!teamName || !state.teamsToCompare.has(teamName)) return;
 
-            const { assetId, assetLabel, assetKtc, assetPos } = assetRow.dataset;
+            const { assetId, assetLabel, assetKtc, assetPos, assetBasePos, assetTeam } = assetRow.dataset;
             if (!assetId) return;
 
             if (!state.tradeBlock[teamName]) {
@@ -528,7 +528,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     id: assetId,
                     label: assetLabel,
                     ktc: parseInt(assetKtc, 10) || 0,
-                    pos: assetPos
+                    pos: assetPos,
+                    basePos: assetBasePos || assetPos,
+                    team: assetTeam || ''
                 });
                 assetRow.classList.add('player-selected');
             }
@@ -1759,7 +1761,21 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     const assets = state.tradeBlock[teamName];
                     assets.forEach(asset => {
                         if (asset.pos !== 'DP') {
-                            selectedPlayersWithTeams.push({ ...asset, teamName });
+                            const fullPlayer = state.players[asset.id];
+                            const playerName = fullPlayer
+                                ? `${fullPlayer.first_name} ${fullPlayer.last_name}`
+                                : asset.label;
+                            const normalizedTeam = (asset.team || fullPlayer?.team || 'FA').toUpperCase();
+                            const primaryPos = (asset.basePos || fullPlayer?.position || asset.pos || '').toUpperCase();
+
+                            selectedPlayersWithTeams.push({
+                                ...asset,
+                                teamName,
+                                name: playerName,
+                                pos: primaryPos || asset.pos,
+                                displayPos: asset.pos,
+                                team: normalizedTeam
+                            });
                         }
                     });
                 }
@@ -1799,20 +1815,56 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             playerNamesRow.className = 'player-names-row';
             players.forEach(player => {
                 const fullPlayer = state.players[player.id];
-                const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
+                const playerName = player.name || (fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label);
 
                 const headerContainer = document.createElement('div');
                 headerContainer.className = 'player-name-header-container';
 
-                headerContainer.innerHTML = `
-                    <div class="player-name-header">${playerName}<br><span class="game-log-link">Game Log</span></div>
-                `;
+                const nameHeader = document.createElement('div');
+                nameHeader.className = 'player-name-header';
 
-                const gameLogLink = headerContainer.querySelector('.game-log-link');
-                gameLogLink.onclick = () => {
+                const nameButton = document.createElement('button');
+                nameButton.type = 'button';
+                nameButton.className = 'player-name-header-link';
+                nameButton.textContent = playerName;
+                nameButton.onclick = () => {
                     state.isGameLogModalOpenFromComparison = true;
-                    handlePlayerNameClick(player);
+                    const resolvedTeam = player.team || fullPlayer?.team || 'FA';
+                    const playerForLogs = {
+                        id: player.id,
+                        name: player.name || playerName,
+                        pos: player.pos,
+                        team: resolvedTeam
+                    };
+                    handlePlayerNameClick(playerForLogs);
                 };
+
+                const tagsRow = document.createElement('div');
+                tagsRow.className = 'player-header-tags';
+
+                const posTag = document.createElement('div');
+                posTag.className = `player-tag modal-pos-tag ${player.pos}`;
+                posTag.textContent = player.pos;
+
+                const teamKey = (player.team || fullPlayer?.team || 'FA').toUpperCase();
+                const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
+                const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+                const src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+                const teamLogoChip = document.createElement('div');
+                teamLogoChip.className = 'player-tag modal-team-logo-chip';
+                if (teamKey && teamKey !== 'FA') {
+                    teamLogoChip.dataset.team = teamKey;
+                    teamLogoChip.innerHTML = `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="20" height="20" loading="lazy">`;
+                } else {
+                    teamLogoChip.innerHTML = '<span>FA</span>';
+                }
+
+                tagsRow.appendChild(posTag);
+                tagsRow.appendChild(teamLogoChip);
+
+                nameHeader.appendChild(nameButton);
+                nameHeader.appendChild(tagsRow);
+                headerContainer.appendChild(nameHeader);
 
                 playerNamesRow.appendChild(headerContainer);
             });
@@ -1883,7 +1935,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
                 const th = document.createElement('th');
                 th.className = 'player-header';
-                th.innerHTML = `<h4>${playerName}</h4><span class="player-pos-team">${player.pos} - ${fullPlayer.team || 'FA'}</span>`;
+                th.innerHTML = `<h4>${playerName}</h4>`;
                 tr.appendChild(th);
             });
             thead.appendChild(tr);
@@ -2453,6 +2505,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;
             row.dataset.assetPos = displaySlot;
+            row.dataset.assetBasePos = (player.pos || displaySlot || '').toUpperCase();
+            row.dataset.assetTeam = (player.team || 'FA').toUpperCase();
 
             if (state.tradeBlock[teamName]?.find(a => a.id === player.id)) {
                 row.classList.add('player-selected');
@@ -2981,7 +3035,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     const tradePreviewRect = tradePreview.getBoundingClientRect();
 
                     const topPosition = headerRect.bottom + 10;
-                    const availableHeight = tradePreviewRect.top - topPosition - 10;
+                    const spacingAdjustment = 6;
+                    const availableHeight = tradePreviewRect.top - topPosition - spacingAdjustment;
 
                     modalContent.style.top = `${topPosition}px`;
                     modalContent.style.height = `${availableHeight}px`;

--- a/DH_P2-5.178/styles/styles.css
+++ b/DH_P2-5.178/styles/styles.css
@@ -2726,6 +2726,11 @@ font-weight: 500 !important;
     color: var(--color-text-primary);
 }
 
+#player-comparison-modal .modal-footer {
+    margin-top: 0.55rem;
+    margin-bottom: 0.05rem;
+}
+
 .modal-info-btn {
     font-size: 0.8rem;
     line-height: 0.8rem; /* Keep icon slightly larger than text */
@@ -2860,7 +2865,7 @@ font-weight: 500 !important;
     .player-comparison-container {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.4rem;
         flex: 1;
         min-height: 0;
     }
@@ -2880,6 +2885,55 @@ font-weight: 500 !important;
         font-weight: 700;
         color: var(--color-text-primary);
         line-height: 1.1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.3rem;
+    }
+
+    .player-name-header-link {
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        padding: 0;
+        text-decoration: none;
+        transition: color 0.2s ease, text-decoration-color 0.2s ease;
+    }
+
+    .player-name-header-link:hover,
+    .player-name-header-link:focus-visible {
+        color: var(--color-accent-primary);
+        text-decoration: underline;
+        outline: none;
+    }
+
+    .player-header-tags {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.35rem;
+        margin-top: 0.1rem;
+    }
+
+    .player-header-tags .modal-pos-tag {
+        font-size: 0.75rem;
+        padding: 3px 6px;
+        line-height: 0.85rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip {
+        padding: 1px 5px;
+    }
+
+    .player-header-tags .modal-team-logo-chip span {
+        font-size: 0.7rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip img.team-logo {
+        width: 18px;
+        height: 18px;
     }
     
     #close-comparison-key {
@@ -2899,9 +2953,9 @@ font-weight: 500 !important;
     .comparison-summary-chips-row {
         display: flex;
         justify-content: center;
-        gap: 1rem;
+        gap: 0.75rem;
         flex-wrap: wrap;
-        padding: 0.5rem 0;
+        padding: 0.35rem 0;
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
@@ -2921,7 +2975,7 @@ font-weight: 500 !important;
     .summary-chips-container {
         display: flex;
         flex-direction: column;
-        gap: 0.25rem;
+        gap: 0.2rem;
     }
     
     /* · · Player Comp Table · · */
@@ -2971,7 +3025,7 @@ font-weight: 500 !important;
         
         /* · · Summary Chips · · */
     #player-comparison-modal .summary-chip {
-        padding: 0.3rem 0.9rem; /* Further reduced padding */
+        padding: 0.24rem 0.85rem; /* Further reduced padding */
         text-align: center;
         min-width: auto;
         position: relative;
@@ -2993,10 +3047,10 @@ font-weight: 500 !important;
         font-size: 0.7rem;
         font-weight: 700;
         color: var(--color-text-secondary);
-        margin-bottom: 0.1rem;
+        margin-bottom: 0.05rem;
         text-transform: uppercase;
         border-bottom: 1px solid var(--color-panel-border);
-        padding-bottom: 0.1rem;
+        padding-bottom: 0.08rem;
         gap: 0.5rem;
     }
 #player-comparison-modal .summary-chip .chip-separator {
@@ -3190,7 +3244,8 @@ font-weight: 500 !important;
     }
 
     #player-comparison-modal .comparison-summary-chips-row {
-        gap: 0.5rem;
+        gap: 0.4rem;
+        padding: 0.25rem 0;
     }
 
     #player-comparison-modal .summary-chips-container {
@@ -3713,6 +3768,7 @@ img.team-logo.glow[alt="WAS"] {
   transform: none;        /* no scale animation */
   opacity: 1;
   pointer-events: auto;   /* clickable */
+  padding-bottom: 0.05rem;
 }
 
 /* · · Overlay · · */


### PR DESCRIPTION
## Summary
- enrich comparison modal selections with base position and team info so player name links open the correct game log header
- capture roster row metadata when players are selected for comparison to feed the modal tags and roster-style game log presentation
- nudge the comparison modal layout by lowering the key button, extending the table area, and slightly increasing modal height for better fit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccf7c4f8ec832e9552569e737cc430