### PR TITLE
Fix comparison modal game log data and layout

### DIFF
--- a/DH_P2-5.178/scripts/app.js
+++ b/DH_P2-5.178/scripts/app.js
@@ -511,7 +511,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const teamName = assetRow.closest('.roster-column')?.dataset.teamName;
             if (!teamName || !state.teamsToCompare.has(teamName)) return;
 
-            const { assetId, assetLabel, assetKtc, assetPos } = assetRow.dataset;
+            const { assetId, assetLabel, assetKtc, assetPos, assetBasePos, assetTeam } = assetRow.dataset;
             if (!assetId) return;
 
             if (!state.tradeBlock[teamName]) {
@@ -528,7 +528,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     id: assetId,
                     label: assetLabel,
                     ktc: parseInt(assetKtc, 10) || 0,
-                    pos: assetPos
+                    pos: assetPos,
+                    basePos: assetBasePos || assetPos,
+                    team: assetTeam || ''
                 });
                 assetRow.classList.add('player-selected');
             }
@@ -1759,7 +1761,21 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     const assets = state.tradeBlock[teamName];
                     assets.forEach(asset => {
                         if (asset.pos !== 'DP') {
-                            selectedPlayersWithTeams.push({ ...asset, teamName });
+                            const fullPlayer = state.players[asset.id];
+                            const playerName = fullPlayer
+                                ? `${fullPlayer.first_name} ${fullPlayer.last_name}`
+                                : asset.label;
+                            const normalizedTeam = (asset.team || fullPlayer?.team || 'FA').toUpperCase();
+                            const primaryPos = (asset.basePos || fullPlayer?.position || asset.pos || '').toUpperCase();
+
+                            selectedPlayersWithTeams.push({
+                                ...asset,
+                                teamName,
+                                name: playerName,
+                                pos: primaryPos || asset.pos,
+                                displayPos: asset.pos,
+                                team: normalizedTeam
+                            });
                         }
                     });
                 }
@@ -1799,71 +1815,188 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             playerNamesRow.className = 'player-names-row';
             players.forEach(player => {
                 const fullPlayer = state.players[player.id];
-                const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
+                const playerName = player.name || (fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label);
 
                 const headerContainer = document.createElement('div');
                 headerContainer.className = 'player-name-header-container';
 
-                headerContainer.innerHTML = `
-                    <div class="player-name-header">${playerName}<br><span class="game-log-link">Game Log</span></div>
-                `;
+                const nameHeader = document.createElement('div');
+                nameHeader.className = 'player-name-header';
 
-                const gameLogLink = headerContainer.querySelector('.game-log-link');
-                gameLogLink.onclick = () => {
+                const nameButton = document.createElement('button');
+                nameButton.type = 'button';
+                nameButton.className = 'player-name-header-link';
+                nameButton.textContent = playerName;
+                nameButton.onclick = () => {
                     state.isGameLogModalOpenFromComparison = true;
-                    handlePlayerNameClick(player);
+
+                    const rosterMeta = getPlayerData(player.id, player.displayPos || player.pos || '');
+                    const valuations = state.isSuperflex ? state.sflxData[player.id] : state.oneQbData[player.id];
+
+                    const parseNumeric = (value) => {
+                        if (typeof value === 'number' && Number.isFinite(value)) return value;
+                        if (typeof value === 'string') {
+                            const stripped = value.replace(/[^0-9.\-]/g, '');
+                            const parsed = Number(stripped);
+                            return Number.isFinite(parsed) ? parsed : null;
+                        }
+                        const parsed = Number(value);
+                        return Number.isFinite(parsed) ? parsed : null;
+                    };
+
+                    const firstValidNumber = (candidates, { allowZero = false } = {}) => {
+                        for (const candidate of candidates) {
+                            const parsed = parseNumeric(candidate);
+                            if (parsed === null) continue;
+                            if (!allowZero && parsed <= 0) continue;
+                            return parsed;
+                        }
+                        return null;
+                    };
+
+                    const basePos = (player.pos || rosterMeta.pos || fullPlayer?.position || '').toUpperCase();
+                    const canonicalPos = basePos || 'FA';
+                    const resolvedTeam = (player.team || rosterMeta.team || fullPlayer?.team || 'FA').toUpperCase();
+
+                    const ktcValue = firstValidNumber([
+                        player.ktc,
+                        rosterMeta.ktc,
+                        valuations?.ktc
+                    ]);
+
+                    const overallRankValue = firstValidNumber([
+                        player.overallRank,
+                        rosterMeta.overallRank,
+                        valuations?.overallRank,
+                        valuations?.overall_rank_ppr
+                    ]);
+
+                    const posRankNumeric = firstValidNumber([
+                        player.posRank,
+                        rosterMeta.posRank,
+                        valuations?.posRank,
+                        valuations?.pos_rank_ppr
+                    ]);
+
+                    const mergedPlayerData = {
+                        id: player.id,
+                        name: player.name || playerName,
+                        pos: canonicalPos,
+                        team: resolvedTeam,
+                        ktc: ktcValue,
+                        overallRank: overallRankValue ?? null,
+                        posRank: posRankNumeric ? `${canonicalPos}·${posRankNumeric}` : null
+                    };
+
+                    handlePlayerNameClick(mergedPlayerData);
                 };
+                const tagsRow = document.createElement('div');
+                tagsRow.className = 'player-header-tags';
+
+                const posTag = document.createElement('div');
+                posTag.className = `player-tag modal-pos-tag ${player.pos}`;
+                posTag.textContent = player.pos;
+
+                const teamKey = (player.team || fullPlayer?.team || 'FA').toUpperCase();
+                const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
+                const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
+                const src = `../assets/NFL-Tags_webp/${normalizedKey}.webp`;
+                const teamLogoChip = document.createElement('div');
+                teamLogoChip.className = 'player-tag modal-team-logo-chip';
+                if (teamKey && teamKey !== 'FA') {
+                    teamLogoChip.dataset.team = teamKey;
+                    teamLogoChip.innerHTML = `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="20" height="20" loading="lazy">`;
+                } else {
+                    teamLogoChip.innerHTML = '<span>FA</span>';
+                }
+
+                tagsRow.appendChild(posTag);
+                tagsRow.appendChild(teamLogoChip);
+
+                nameHeader.appendChild(nameButton);
+                nameHeader.appendChild(tagsRow);
+                headerContainer.appendChild(nameHeader);
 
                 playerNamesRow.appendChild(headerContainer);
             });
             container.appendChild(playerNamesRow);
         
-                // Summary Chips Row
-        const summaryChipsRow = document.createElement('div');
-        summaryChipsRow.className = 'comparison-summary-chips-row';
-        
-        players.forEach(player => {
-          const summaryChipsContainer = document.createElement('div');
-          summaryChipsContainer.className = 'summary-chips-container';
-          const overallRankDisplay = typeof player.overallRank === 'number' ? `#${player.overallRank}` : (player.overallRank || 'NA');
-          const posRankDisplay = typeof player.posRank === 'number' ? player.posRank : (player.posRank || 'NA');
-          const ppgOverallRankDisplay = typeof player.ppgOverallRank === 'number' ? `#${player.ppgOverallRank}` : (player.ppgOverallRank || 'NA');
-          const ppgPosRankDisplay = typeof player.ppgPosRank === 'number' ? player.ppgPosRank : (player.ppgPosRank || 'NA');
-          summaryChipsContainer.innerHTML = `
-            <div class="summary-chip">
-              <h4>
-                <span class="chip-header-value" style="color: ${getConditionalColorByRank(player.posRank)}">${player.total_pts} </span>
-                <span class="chip-unit"> FPTS</span>
-              </h4>
-              <div class="chip-values">
-                <span style="color: ${getRankColor(player.overallRank)}">${overallRankDisplay}</span>
-                <span class="chip-separator">•</span>
-                <span class="pos-rank-container">
-                  <span class="chip-pos-rank-label pos-color-${player.pos}">${player.pos}·</span>
-                  <span style="color: ${getConditionalColorByRank(player.posRank)}">${posRankDisplay}</span>
-                </span>
-              </div>
-            </div>
+            // Summary Chips Row
+            const summaryChipsRow = document.createElement('div');
+            summaryChipsRow.className = 'comparison-summary-chips-row';
 
-            <div class="summary-chip">
-              <h4>
-                <span class="chip-header-value" style="color: ${getConditionalColorByRank(player.ppgPosRank)}">${player.ppg}</span>
-                <span class="chip-unit"> PPG</span>
-              </h4>
-              <div class="chip-values">
-                <span style="color: ${getRankColor(player.ppgOverallRank)}">${ppgOverallRankDisplay}</span>
-                <span class="chip-separator">•</span>
-                <span class="pos-rank-container">
-                  <span class="chip-pos-rank-label pos-color-${player.pos}">${player.pos}·</span>
-                  <span style="color: ${getConditionalColorByRank(player.ppgPosRank)}">${ppgPosRankDisplay}</span>
-                </span>
-              </div>
-            </div>
-          `;
-          summaryChipsRow.appendChild(summaryChipsContainer);
-        });
-        
-        container.appendChild(summaryChipsRow);
+            players.forEach(player => {
+                const summaryChipsContainer = document.createElement('div');
+                summaryChipsContainer.className = 'summary-chips-container';
+
+                const overallRankNumber = typeof player.overallRank === 'number' ? player.overallRank : Number(player.overallRank);
+                const overallRankDisplay = Number.isFinite(overallRankNumber)
+                  ? `#${overallRankNumber}`
+                  : (player.overallRank || 'NA');
+
+                const rawPosRank = player.posRank;
+                const posRankNumber = typeof rawPosRank === 'number'
+                  ? rawPosRank
+                  : Number.parseInt(String(rawPosRank).split('·')[1] || String(rawPosRank), 10);
+                const posRankDisplay = Number.isFinite(posRankNumber)
+                  ? posRankNumber
+                  : (rawPosRank || 'NA');
+                const posRankColor = Number.isFinite(posRankNumber)
+                  ? getConditionalColorByRank(posRankNumber)
+                  : 'inherit';
+
+                const ppgOverallRankNumber = typeof player.ppgOverallRank === 'number'
+                  ? player.ppgOverallRank
+                  : Number(player.ppgOverallRank);
+                const ppgOverallRankDisplay = Number.isFinite(ppgOverallRankNumber)
+                  ? `#${ppgOverallRankNumber}`
+                  : (player.ppgOverallRank || 'NA');
+
+                const ppgPosRankNumber = typeof player.ppgPosRank === 'number'
+                  ? player.ppgPosRank
+                  : Number(player.ppgPosRank);
+                const ppgPosRankDisplay = Number.isFinite(ppgPosRankNumber)
+                  ? ppgPosRankNumber
+                  : (player.ppgPosRank || 'NA');
+                const ppgPosRankColor = Number.isFinite(ppgPosRankNumber)
+                  ? getConditionalColorByRank(ppgPosRankNumber)
+                  : 'inherit';
+
+                summaryChipsContainer.innerHTML = `
+                  <div class="summary-chip">
+                    <h4>
+                      <span class="chip-header-value" style="color: ${posRankColor}">${player.total_pts}</span>
+                      <span class="chip-unit"> FPTS</span>
+                    </h4>
+                    <div class="chip-values">
+                      <span style="color: ${getRankColor(overallRankNumber)}">${overallRankDisplay}</span>
+                      <span class="chip-separator">•</span>
+                      <span class="pos-rank-container">
+                        <span class="chip-pos-rank-label pos-color-${player.pos}">${player.pos}·</span>
+                        <span style="color: ${posRankColor}">${posRankDisplay}</span>
+                      </span>
+                    </div>
+                  </div>
+
+                  <div class="summary-chip">
+                    <h4>
+                      <span class="chip-header-value" style="color: ${ppgPosRankColor}">${player.ppg}</span>
+                      <span class="chip-unit"> PPG</span>
+                    </h4>
+                    <div class="chip-values">
+                      <span style="color: ${getRankColor(ppgOverallRankNumber)}">${ppgOverallRankDisplay}</span>
+                      <span class="chip-separator">•</span>
+                      <span class="pos-rank-container">
+                        <span class="chip-pos-rank-label pos-color-${player.pos}">${player.pos}·</span>
+                        <span style="color: ${ppgPosRankColor}">${ppgPosRankDisplay}</span>
+                      </span>
+                    </div>
+                  </div>
+                `;
+                summaryChipsRow.appendChild(summaryChipsContainer);
+            });
+
+            container.appendChild(summaryChipsRow);
 
 
             // Detailed Stats Table
@@ -1883,7 +2016,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
                 const th = document.createElement('th');
                 th.className = 'player-header';
-                th.innerHTML = `<h4>${playerName}</h4><span class="player-pos-team">${player.pos} - ${fullPlayer.team || 'FA'}</span>`;
+                th.innerHTML = `<h4>${playerName}</h4>`;
                 tr.appendChild(th);
             });
             thead.appendChild(tr);
@@ -2453,6 +2586,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;
             row.dataset.assetPos = displaySlot;
+            row.dataset.assetBasePos = (player.pos || displaySlot || '').toUpperCase();
+            row.dataset.assetTeam = (player.team || 'FA').toUpperCase();
 
             if (state.tradeBlock[teamName]?.find(a => a.id === player.id)) {
                 row.classList.add('player-selected');
@@ -2981,7 +3116,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     const tradePreviewRect = tradePreview.getBoundingClientRect();
 
                     const topPosition = headerRect.bottom + 10;
-                    const availableHeight = tradePreviewRect.top - topPosition - 10;
+                    const spacingAdjustment = 6;
+                    const availableHeight = tradePreviewRect.top - topPosition - spacingAdjustment;
 
                     modalContent.style.top = `${topPosition}px`;
                     modalContent.style.height = `${availableHeight}px`;

--- a/DH_P2-5.178/styles/styles.css
+++ b/DH_P2-5.178/styles/styles.css
@@ -2726,6 +2726,11 @@ font-weight: 500 !important;
     color: var(--color-text-primary);
 }
 
+#player-comparison-modal .modal-footer {
+    margin-top: 0.25rem;
+    margin-bottom: 0.05rem;
+}
+
 .modal-info-btn {
     font-size: 0.8rem;
     line-height: 0.8rem; /* Keep icon slightly larger than text */
@@ -2860,7 +2865,7 @@ font-weight: 500 !important;
     .player-comparison-container {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.3rem;
         flex: 1;
         min-height: 0;
     }
@@ -2880,6 +2885,55 @@ font-weight: 500 !important;
         font-weight: 700;
         color: var(--color-text-primary);
         line-height: 1.1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.3rem;
+    }
+
+    .player-name-header-link {
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        padding: 0;
+        text-decoration: none;
+        transition: color 0.2s ease, text-decoration-color 0.2s ease;
+    }
+
+    .player-name-header-link:hover,
+    .player-name-header-link:focus-visible {
+        color: var(--color-accent-primary);
+        text-decoration: underline;
+        outline: none;
+    }
+
+    .player-header-tags {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.35rem;
+        margin-top: 0.1rem;
+    }
+
+    .player-header-tags .modal-pos-tag {
+        font-size: 0.75rem;
+        padding: 3px 6px;
+        line-height: 0.85rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip {
+        padding: 1px 5px;
+    }
+
+    .player-header-tags .modal-team-logo-chip span {
+        font-size: 0.7rem;
+    }
+
+    .player-header-tags .modal-team-logo-chip img.team-logo {
+        width: 18px;
+        height: 18px;
     }
     
     #close-comparison-key {
@@ -2899,9 +2953,9 @@ font-weight: 500 !important;
     .comparison-summary-chips-row {
         display: flex;
         justify-content: center;
-        gap: 1rem;
+        gap: 0.75rem;
         flex-wrap: wrap;
-        padding: 0.5rem 0;
+        padding: 0.35rem 0;
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
@@ -2921,7 +2975,7 @@ font-weight: 500 !important;
     .summary-chips-container {
         display: flex;
         flex-direction: column;
-        gap: 0.25rem;
+        gap: 0.2rem;
     }
     
     /* · · Player Comp Table · · */
@@ -2971,7 +3025,7 @@ font-weight: 500 !important;
         
         /* · · Summary Chips · · */
     #player-comparison-modal .summary-chip {
-        padding: 0.3rem 0.9rem; /* Further reduced padding */
+        padding: 0.24rem 0.85rem; /* Further reduced padding */
         text-align: center;
         min-width: auto;
         position: relative;
@@ -2993,10 +3047,10 @@ font-weight: 500 !important;
         font-size: 0.7rem;
         font-weight: 700;
         color: var(--color-text-secondary);
-        margin-bottom: 0.1rem;
+        margin-bottom: 0.05rem;
         text-transform: uppercase;
         border-bottom: 1px solid var(--color-panel-border);
-        padding-bottom: 0.1rem;
+        padding-bottom: 0.08rem;
         gap: 0.5rem;
     }
 #player-comparison-modal .summary-chip .chip-separator {
@@ -3190,7 +3244,8 @@ font-weight: 500 !important;
     }
 
     #player-comparison-modal .comparison-summary-chips-row {
-        gap: 0.5rem;
+        gap: 0.4rem;
+        padding: 0.25rem 0;
     }
 
     #player-comparison-modal .summary-chips-container {
@@ -3713,6 +3768,7 @@ img.team-logo.glow[alt="WAS"] {
   transform: none;        /* no scale animation */
   opacity: 1;
   pointer-events: auto;   /* clickable */
+  padding-bottom: 0.05rem;
 }
 
 /* · · Overlay · · */


### PR DESCRIPTION
## Summary
- ensure comparison modal player-name clicks rebuild roster-style metadata so the game log modal matches the roster behavior and carries correct KTC/rank data
- remove the comparison modal KTC summary chip to keep the comparison layout aligned with the requested design while preserving the added tags and spacing tweaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf7c4f8ec832e9552569e737cc430