### PR TITLE
Fix roster sheet parsing after new 1DRR column

### DIFF
--- a/DH_P2-5.178B/analyzer/analyzer.html
+++ b/DH_P2-5.178B/analyzer/analyzer.html
@@ -363,22 +363,85 @@
             
             function parseSheetData(csvText) {
                 const dataMap = {};
-                const lines = csvText.split(/\r?\n/).slice(1);
-                lines.forEach(line => {
-                    const columns = line.match(/(".*?"|[^",]+)(?=\s*,|\s*$)/g) || [];
-                    if (columns.length < 13) return;
-                    const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
-                    const pos = clean(columns[2]);
-                    const sleeperId = clean(columns[12]);
-                    const ktcValue = parseInt(clean(columns[6]), 10);
+                const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
+                if (lines.length === 0) return dataMap;
+
+                const parseLine = (line) => {
+                    const result = [];
+                    let current = '';
+                    let inQuotes = false;
+                    const sanitized = line.replace(/\r$/, '');
+
+                    for (let i = 0; i < sanitized.length; i++) {
+                        const char = sanitized[i];
+                        if (inQuotes) {
+                            if (char === '"') {
+                                if (sanitized[i + 1] === '"') {
+                                    current += '"';
+                                    i++;
+                                } else {
+                                    inQuotes = false;
+                                }
+                            } else {
+                                current += char;
+                            }
+                        } else if (char === '"') {
+                            inQuotes = true;
+                        } else if (char === ',') {
+                            result.push(current.trim());
+                            current = '';
+                        } else {
+                            current += char;
+                        }
+                    }
+                    result.push(current.trim());
+                    return result;
+                };
+
+                const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
+                const headers = parseLine(lines[0]).map(cell => cell.trim());
+                const headerIndex = new Map();
+                headers.forEach((header, idx) => {
+                    headerIndex.set(normalize(header), idx);
+                });
+
+                const getValue = (columns, names) => {
+                    const keys = Array.isArray(names) ? names : [names];
+                    for (const name of keys) {
+                        const idx = headerIndex.get(normalize(name));
+                        if (idx !== undefined && columns[idx] !== undefined) {
+                            return columns[idx].trim();
+                        }
+                    }
+                    return '';
+                };
+
+                const toInt = (value) => {
+                    const num = parseInt(value, 10);
+                    return Number.isNaN(num) ? null : num;
+                };
+
+                lines.slice(1).forEach(line => {
+                    const columns = parseLine(line);
+                    if (!columns.length) return;
+
+                    const pos = getValue(columns, 'POS');
+                    const sleeperId = getValue(columns, 'SLPR_ID');
+                    const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
 
                     if (pos === 'RDP') {
-                        const pickName = clean(columns[1]);
-                        if (pickName) dataMap[pickName] = { ktc: ktcValue };
-                    } else if (sleeperId && sleeperId !== 'NA') {
-                        dataMap[sleeperId] = { ktc: isNaN(ktcValue) ? 0 : ktcValue };
+                        const pickName = getValue(columns, 'PLAYER NAME');
+                        if (pickName) {
+                            dataMap[pickName] = { ktc: ktcValue };
+                        }
+                        return;
                     }
+
+                    if (!sleeperId || sleeperId === 'NA') return;
+
+                    dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
                 });
+
                 return dataMap;
             }
 

--- a/DH_P2-5.178B/scripts/app.js
+++ b/DH_P2-5.178B/scripts/app.js
@@ -736,33 +736,71 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         function parseSheetData(csvText) {
             const dataMap = {};
-            const lines = csvText.split(/\r?\n/).slice(1);
-            lines.forEach(line => {
-                const columns = line.match(/(".*?"|[^",]+)(?=\s*,|\s*$)/g) || [];
-                if (columns.length < 13) return;
-                const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
-                const pos = clean(columns[2]);
-                const sleeperId = clean(columns[12]);
-                const adp = parseFloat(clean(columns[11]));
-                const ktcValue = parseInt(clean(columns[6]), 10);
-                const posRank = clean(columns[7]);
-                const age = parseFloat(clean(columns[3])); // CORRECTED: Read age from the 4th column (index 3)
-                const overallRank = parseInt(clean(columns[0]), 10); // ADDED: Read overall rank from the 1st column (index 0)
+            const { headers, rows } = parseCsv(csvText);
+            if (!headers.length || !rows.length) return dataMap;
+
+            const normalizedHeaders = headers.map(normalizeHeader);
+            const headerIndex = new Map();
+            normalizedHeaders.forEach((header, idx) => {
+                headerIndex.set(header.toUpperCase(), idx);
+            });
+
+            const normalizeKey = (key) => normalizeHeader(key).toUpperCase();
+            const getColumnValue = (columns, names) => {
+                const keys = Array.isArray(names) ? names : [names];
+                for (const name of keys) {
+                    const idx = headerIndex.get(normalizeKey(name));
+                    if (idx !== undefined) {
+                        const value = columns[idx];
+                        if (value !== undefined) return value.trim();
+                    }
+                }
+                return '';
+            };
+
+            const toFloat = (value) => {
+                const num = parseFloat(value);
+                return Number.isNaN(num) ? null : num;
+            };
+
+            const toInt = (value) => {
+                const num = parseInt(value, 10);
+                return Number.isNaN(num) ? null : num;
+            };
+
+            rows.forEach(columns => {
+                const pos = getColumnValue(columns, 'POS');
+                const sleeperId = getColumnValue(columns, 'SLPR_ID');
+                const ktcValue = toInt(getColumnValue(columns, ['VALUE', 'KTC']));
+                const adp = toFloat(getColumnValue(columns, 'ADP'));
+                const posRank = getColumnValue(columns, ['POS·RK', 'POS RK', 'POS_RK']);
+                const age = toFloat(getColumnValue(columns, 'AGE'));
+                const overallRank = toInt(getColumnValue(columns, ['RANK', 'OVR', 'OVERALL']));
 
                 if (pos === 'RDP') {
-                    const pickName = clean(columns[1]);
-                    if (pickName) dataMap[pickName] = { adp: null, ktc: ktcValue, posRank: null, overallRank: null };
-                } else if (sleeperId && sleeperId !== 'NA') {
-                    // Add the parsed age and overall rank to the player's data object
-                    dataMap[sleeperId] = {
-                        age: isNaN(age) ? null : age,
-                        adp: isNaN(adp) ? null : adp,
-                        ktc: isNaN(ktcValue) ? null : ktcValue,
-                        posRank: posRank,
-                        overallRank: isNaN(overallRank) ? null : overallRank
-                    };
+                    const pickName = getColumnValue(columns, 'PLAYER NAME');
+                    if (pickName) {
+                        dataMap[pickName] = {
+                            adp: null,
+                            ktc: ktcValue,
+                            posRank: null,
+                            overallRank: null
+                        };
+                    }
+                    return;
                 }
+
+                if (!sleeperId || sleeperId === 'NA') return;
+
+                dataMap[sleeperId] = {
+                    age: age,
+                    adp: adp,
+                    ktc: ktcValue,
+                    posRank: posRank || null,
+                    overallRank: overallRank
+                };
             });
+
             return dataMap;
         }
 


### PR DESCRIPTION
## Summary
- update the shared roster sheet parser to locate Sleeper id, value, ADP, etc. by column header so adding columns like `1DRR` no longer breaks parsing
- mirror the header-aware parsing in the analyzer so KTC values and rookie pick rows continue to load correctly

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd178caf58832e93348cc64e44a6ba